### PR TITLE
Updates to support world state

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/dist/index.js",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ]
+        }
+    ]
+}

--- a/README.MD
+++ b/README.MD
@@ -27,10 +27,54 @@ Below is a list of commands.
         type: string = "ping_response",
         visibility: string = "private",
         playerId: integer = [player's peer identification],
-        lastActivity: integer? = [player's last message receipt UTC timestamp]
+        ts: integer = [player's last message receipt UTC timestamp]
     }
     ```
 
 * `pong`
     - Exists mainly as a debug tool. Lets the server know that the client is still connected for printable messages via code. No response is sent to the client.
+
+### Global messages
+
+The server will send out world update packets to players on a regular interval. These messages are as follows:
+
+```
+{
+    type: string = "state",
+    ts: integer = UTC timestamp,
+    data: {
+        players: [{
+            id: integer,
+            lastActivity: number? = UTC timestamp,
+            pos: Vector3,
+            rot: Vector4,
+            lHandPos: Vector3,
+            lHandRot: Vector4,
+            lHandObj: string,
+            rHandPos: Vector3,
+            rHandRot: Vector4,
+            rHandObj: string,
+            faceTx: string,
+            bodyTx: string
+        }],
+        enemies: [{
+            enemyType: string,
+            hp: integer,
+            target: string,
+            pos: Vector3,
+            rot: Vector4
+        }]
+    }
+}
+```
+
+
+### Channel usage
+
+Enet provides the ability to use multiple channels. Best practice is to separate communication into channels logically for performance.
+
+For this server channels are used as follows:
+
+* 0 : Base bi-directional game communication
+* 1 : Server to client broadcasts 
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { Address, createServer, Host, Packet, Peer } from "enet";
+import { Address, createServer, Host, Packet, PACKET_FLAG, Peer } from "enet";
 import { RequestMessageType, ResponseMessageType, VisibilityLevelType } from "./enums";
 import { IResponseObject } from "./interfaces";
 import { MessageHandlerBase, PingMessageHandler } from "./message-handlers";
@@ -13,12 +13,15 @@ export class App {
     private readonly downLimit: number = 0;
     private readonly upLimit: number = 0;
     private readonly loopIntervalMs: number = 10;
+    private readonly worldBroadcastIntervalMs: number = 200;
+    private readonly missedPacketThreshold: number = 25;
     private readonly serverData: ServerData = new ServerData(this.peerCount);
 
     private gameServer: Host;
+    private worldBroadcastInterval;
 
     public async start(): Promise<void> {
-        console.log("Starting server...");
+        console.info("Starting server...");
 
         this.gameServer = createServer({
             address: this.addr,
@@ -28,28 +31,30 @@ export class App {
             up: this.upLimit
         }, (err: any, host: Host) => {
             if (err) {
-                console.log("Error starting server", err);
+                console.error("Error starting server", err);
                 return;
             }
 
             host.on("connect", (peer: Peer, data: any) => {
-                console.log(`Peer ${peer._pointer} connected`);
+                console.info(`Peer ${peer._pointer} connected`);
 
                 const newPlayer = new Player();
                 newPlayer.id = peer._pointer;
                 newPlayer.lastActivity = ServerService.GetCurrentUtcDate();
 
                 this.serverData.players[peer._pointer] = newPlayer;
+                peer.playerId = newPlayer.id;
 
                 peer.on("disconnect", () => {
-                    this.serverData.players[peer._pointer] = null;
+                    this.handleDisconnect(peer.playerId);
                 });
 
                 peer.on("message", (packet: Packet, channel: number) => {
                     const player = this.serverData.players[peer._pointer];
 
                     if (!player) {
-                        peer.disconnectNow();
+                        const message = `Invalid player ${peer._pointer}`;
+                        this.handleFailure(new Error(message), message, peer);
                     }
 
                     player.lastActivity = ServerService.GetCurrentUtcDate();
@@ -58,7 +63,7 @@ export class App {
                         const gameObject = JSON.parse(packet.data().toString());
 
                         if (gameObject.message_type !== RequestMessageType.Ping) {
-                            console.log(`Got packet from ${player.id} with message_type of ${gameObject.message_type}`);
+                            console.info(`Got packet from ${player.id} with message_type of ${gameObject.message_type}`);
                         }
 
                         let messageHandler: MessageHandlerBase = null;
@@ -81,16 +86,26 @@ export class App {
                             messageHandler,
                             player);
 
-                    } catch(err) {
-                        console.log(`Received malformed packet data from Peer ${peer._pointer}`);
-                        console.log(err);
-                        peer.disconnectNow();
+                    } catch (err) {
+                        this.handleFailure(
+                            err,
+                            `Received malformed packet data from Peer ${peer._pointer}`,
+                            peer);
                     }
                 });
             });
 
             host.start(this.loopIntervalMs);
+
             console.info("Server ready on %s:%s", host.address().address, host.address().port);
+
+            console.info("Starting broadcast interval");
+
+            this.worldBroadcastInterval = setInterval(
+                this.sendGlobalState,
+                this.worldBroadcastIntervalMs,
+                host,
+                this.serverData);
         });
     }
 
@@ -124,10 +139,47 @@ export class App {
                 });
             }
         } catch (err) {
-            console.log(`Error processing response to ${player.id}`)
-            console.log(err);
-            peer.disconnectNow();
+            this.handleFailure(err, `Error processing response to ${player.id}`, peer);
         }
+    }
+
+    private handleFailure(err: any, logMessage: string, peer: Peer): void {
+        console.error(err);
+        console.info(logMessage);
+
+        if (peer) {
+            const numMissed = peer.numMissed ? peer.numMissed : 1;
+            peer.numMissed = numMissed + 1;
+
+            if (numMissed > this.missedPacketThreshold) {
+                this.handleDisconnect(peer._pointer);
+                peer.disconnectNow();
+            }
+        }
+    }
+
+    private handleDisconnect(peerId: number) {
+        console.info(`Peer ${peerId} disconnected`);
+
+        if (peerId) {
+            delete this.serverData.players[peerId];
+        }
+    }
+
+    private sendGlobalState(server: Host, serverData: ServerData): void {
+        if (server === null || server === undefined || server.isOffline() || Object.entries(server.connectedPeers).length === 0) {
+            return;
+        }
+
+        const jsonData = JSON.stringify({
+            type: ResponseMessageType.GlobalState,
+            ts: ServerService.GetCurrentUtcDate(),
+            data: serverData.broadcastData
+        });
+
+        const packet = new Packet(jsonData, PACKET_FLAG.RELIABLE);
+
+        server.broadcast(1, packet);
     }
 
     private sendResponse(peer: Peer, data: IResponseObject, player: Player): void {
@@ -140,21 +192,22 @@ export class App {
 
         peer.send(0, jsonResponse, (err: any) => {
             if (err) {
-                console.log("Error sending packet!");
-                peer.disconnectNow();
+                this.handleFailure(err, `Error sending packet to ${peer._pointer}`, peer);
             } else {
+                peer.numMissed = 0;
+
                 // don't log if ping
                 if (data.type === ResponseMessageType.PingResponse) {
                     return;
                 }
 
-                let message: string = `Message sent successfully to ${playerId ?? "--"}`;
+                let message: string = `Message sent successfully to ${playerId ? playerId : "--"}`;
 
                 if (data.type) {
                     message += ` with message type of ${data.type}`;
                 }
 
-                console.log(message);
+                console.info(message);
             }
         });
     }

--- a/src/enums/response-message-type.enum.ts
+++ b/src/enums/response-message-type.enum.ts
@@ -1,4 +1,5 @@
 export enum ResponseMessageType {
     Error = "error",
+    GlobalState = "state",
     PingResponse = "ping_response",
 }

--- a/src/message-handlers/ping-message-handler.handler.ts
+++ b/src/message-handlers/ping-message-handler.handler.ts
@@ -13,7 +13,7 @@ export class PingMessageHandler extends MessageHandlerBase {
             type: ResponseMessageType.PingResponse,
             visibility: VisibilityLevelType.Private,
             playerId: this.player.id,
-            value: this.player.lastActivity
+            ts: this.player.lastActivity
         };
 
         return [response];

--- a/src/models/server-data.model.ts
+++ b/src/models/server-data.model.ts
@@ -1,14 +1,20 @@
 import { Enemy } from "./enemy.model";
-import { Player } from "./player.model";
 
 export class ServerData {
     public maxPlayerCount: number;
-    public players: Player[];
+    public players: {};
     public enemies: Enemy[];
 
     constructor(maxPlayerCount: number) {
         this.maxPlayerCount = maxPlayerCount;
-        this.players = Array(maxPlayerCount).fill(null);
+        this.players = {};
         this.enemies = [];
+    }
+
+    public get broadcastData(): any {
+        return {
+            players: this.players,
+            enemies: this.enemies
+        };
     }
 }


### PR DESCRIPTION
Closes #1 

Updates server to:
 - Send world state packets on enet channel 2 on a interval (currently 200ms)
 - Update player object in server vars to store players as properties instead of in an array
 - Better client disconnect / error handling
 - Rename timestamp property of packets for brevity